### PR TITLE
Upgrade cucumber and other dependencies

### DIFF
--- a/features/support/env.js
+++ b/features/support/env.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var configure = function () {
+    this.setDefaultTimeout(60 * 1000);
+};
+
+module.exports = configure;

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -23,8 +23,9 @@ var myHooks = function () {
   });
 
   this.registerHandler('AfterFeatures', function (event, callback) {
-    driver.quit();
-    callback();
+    driver.quit().then(function() {
+      callback();
+    });
   });
 
 };

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -43,7 +43,7 @@ var getDriver = function() {
   return driver;
 };
 
-var World = function World(callback) {
+var World = function World() {
 
   var defaultTimeout = 20000;
   var screenshotPath = "screenshots";
@@ -61,8 +61,6 @@ var World = function World(callback) {
       return driver.isElementPresent({ css: cssLocator });
     }, waitTimeout);
   };
-
-  callback();
 };
 
 module.exports.World = World;

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "test": "node_modules/grunt-cli/bin/grunt"
   },
   "devDependencies": {
-    "cucumber": "latest",
-    "selenium-webdriver": "latest",
-    "chai": "latest",
-    "grunt": "latest",
-    "grunt-cli": "latest",
-    "grunt-contrib-jshint": "latest",
-    "grunt-exec": "latest",
-    "grunt-env": "latest",
-    "sanitize-filename": "latest",
-    "appium": "latest"
+    "cucumber": "^0.10.2",
+    "selenium-webdriver": "^2.53.2",
+    "chai": "^3.5.0",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-exec": "^0.4.7",
+    "grunt-env": "^0.4.4",
+    "sanitize-filename": "^1.6.0",
+    "appium": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "test": "node_modules/grunt-cli/bin/grunt"
   },
   "devDependencies": {
-    "cucumber": "0.4.4",
-    "selenium-webdriver": "2.53.1",
-    "chai": "1.10.0",
-    "grunt": "0.4.5",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-jshint": "1.0.0",
-    "grunt-exec": "0.4.6",
-    "grunt-env": "0.4.2",
-    "sanitize-filename": "1.1.1",
-    "appium": "1.3.4"
+    "cucumber": "latest",
+    "selenium-webdriver": "latest",
+    "chai": "latest",
+    "grunt": "latest",
+    "grunt-cli": "latest",
+    "grunt-contrib-jshint": "latest",
+    "grunt-exec": "latest",
+    "grunt-env": "latest",
+    "sanitize-filename": "latest",
+    "appium": "latest"
   }
 }


### PR DESCRIPTION
This PR removes the callback from the world constructor, enabling the use of cucumber versions >= 0.8.0, fixing #2 in the process.

I extended the timeout for step definitions (in env.js) as we don't currently use promises and as such we were falling foul of the default 5000ms timeout while the browser loaded. 

I've also updated all dependencies to their latest versions, and relaxed the package.json a bit so that we'll get updated versions up to the next major version. Nightly builds should let us know if an updated package breaks something.
