### PR TITLE
Return promises in step definitions and hooks

### DIFF
--- a/features/step_definitions/google-steps.js
+++ b/features/step_definitions/google-steps.js
@@ -5,23 +5,19 @@ var expect = require('chai').expect;
 module.exports = function() {
   this.World = require('../support/world.js').World;
 
-  this.When(/^I search Google for "([^"]*)"$/, function (searchQuery, next) {
+  this.When(/^I search Google for "([^"]*)"$/, function (searchQuery) {
     this.driver.get('http://www.google.co.uk/webhp?complete=0');
     this.driver.findElement({ name: 'q' })
       .sendKeys(searchQuery);
-    this.driver.findElement({ name: 'q' })
-      .sendKeys(this.webdriver.Key.ENTER)
-        .then(function() {
-          next();
-        });
+    return this.driver.findElement({ name: 'q' })
+      .sendKeys(this.webdriver.Key.ENTER);
   });
 
-  this.Then(/^I should see some results$/, function (next) {
+  this.Then(/^I should see some results$/, function () {
     this.waitFor('div.g');
-    this.driver.findElements({ css: 'div.g' })
+    return this.driver.findElements({ css: 'div.g' })
       .then(function(elements) {
         expect(elements.length).to.not.equal(0);
-        next();
       });
   });
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -7,7 +7,7 @@ var sanitize = require("sanitize-filename");
 
 var myHooks = function () {
   
-  this.After(function(scenario, callback) {
+  this.After(function(scenario) {
     if(scenario.isFailed()) {
       this.driver.takeScreenshot().then(function(data){
         var base64Data = data.replace(/^data:image\/png;base64,/,"");
@@ -16,16 +16,11 @@ var myHooks = function () {
         });
       });
     }
-    this.driver.manage().deleteAllCookies()
-      .then(function() {
-        callback();
-      });
+    return this.driver.manage().deleteAllCookies();
   });
 
-  this.registerHandler('AfterFeatures', function (event, callback) {
-    driver.quit().then(function() {
-      callback();
-    });
+  this.registerHandler('AfterFeatures', function (event) {
+    return driver.quit();
   });
 
 };


### PR DESCRIPTION
This PR changes from using callbacks in step definitions and hooks to returning promises instead. Advantages of this approach are limited in a small project with such a simple test suite, but this approach slims down the definitions and hooks a little and could help those who build upon this foundation.
