### PR TITLE
Use new travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: precise
 language: node_js
 node_js:
 - node


### PR DESCRIPTION
The build previously defaulted to the precise environment as builds on trusty failed for some reason. They now pass on trusty so this PR removes the config value specifying the legacy env.